### PR TITLE
Added Booth's LCS algorithm as an option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ name = "funkdigen2"
 version = "1.0.0"
 dependencies = [
  "clap",
+ "lazy_static",
 ]
 
 [[package]]
@@ -173,6 +174,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 
 [dependencies]
 clap = { version = "4.2.1", features = ["derive"] }
+lazy_static = "1.4.0"
 
 [profile.release]
 strip = "symbols"


### PR DESCRIPTION
It is now possible (switch `-b` or `--lcs`) to use Booth's LCS algorithm in order to establish if a list is its own minimal rotation. However, for the small values of $n$ that `funkdigen2` handles, this is always slower or equivalent on our test machine.

The code has also been restructured in order to use write-once `lazy_static` globals instead of passing too many parameters everywhere.